### PR TITLE
Add user authentication with login and registration

### DIFF
--- a/db.php
+++ b/db.php
@@ -1,0 +1,6 @@
+<?php
+$mysqli = new mysqli('localhost', 'username', 'password', 'freelancer_hub');
+if ($mysqli->connect_errno) {
+    die('Failed to connect to MySQL: ' . $mysqli->connect_error);
+}
+?>

--- a/index.html
+++ b/index.html
@@ -17,9 +17,10 @@
                 <li><a href="#">About Us</a></li>
                 <li><a href="job-listings.html">Job Listings</a></li>
                 <li><a href="#">Contact Us</a></li>
+                <li><a href="login.php">Login</a></li>
             </ul>
         </nav>
-        <a href="#" class="cta">Register</a>
+        <a href="register.php" class="cta">Register</a>
     </header>
 
     <!-- Hero section introducing the platform -->

--- a/login.php
+++ b/login.php
@@ -1,0 +1,65 @@
+<?php
+session_start();
+require 'db.php';
+
+if (empty($_SESSION['csrf_token'])) {
+    $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+}
+
+$errors = [];
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (!isset($_POST['csrf_token']) || !hash_equals($_SESSION['csrf_token'], $_POST['csrf_token'])) {
+        $errors[] = 'Invalid CSRF token';
+    }
+
+    $email = trim($_POST['email'] ?? '');
+    $password = $_POST['password'] ?? '';
+
+    if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+        $errors[] = 'Invalid email address';
+    }
+
+    if (!$errors) {
+        $stmt = $mysqli->prepare('SELECT id, password, role FROM users WHERE email = ?');
+        $stmt->bind_param('s', $email);
+        $stmt->execute();
+        $result = $stmt->get_result();
+        if ($result && $user = $result->fetch_assoc()) {
+            if (password_verify($password, $user['password'])) {
+                $_SESSION['user_id'] = $user['id'];
+                $_SESSION['user_type'] = $user['role'] === 'freelancer' ? 'freelancer' : 'client';
+                header('Location: profile.php');
+                exit();
+            }
+        }
+        $errors[] = 'Invalid credentials';
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="style.css">
+    <title>Login</title>
+</head>
+<body>
+<header class="site-header">
+    <div class="logo">Freelancer Hub</div>
+</header>
+<div class="form-container">
+    <?php foreach ($errors as $error): ?>
+        <p class="error"><?php echo htmlspecialchars($error); ?></p>
+    <?php endforeach; ?>
+    <form method="post" action="">
+        <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($_SESSION['csrf_token']); ?>">
+        <label>Email: <input type="email" name="email" required></label>
+        <label>Password: <input type="password" name="password" required></label>
+        <button type="submit">Login</button>
+    </form>
+    <p>Don't have an account? <a href="register.php">Register</a></p>
+</div>
+</body>
+</html>

--- a/register.php
+++ b/register.php
@@ -1,0 +1,78 @@
+<?php
+session_start();
+require 'db.php';
+
+if (empty($_SESSION['csrf_token'])) {
+    $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+}
+
+$errors = [];
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (!isset($_POST['csrf_token']) || !hash_equals($_SESSION['csrf_token'], $_POST['csrf_token'])) {
+        $errors[] = 'Invalid CSRF token';
+    }
+
+    $name = trim($_POST['name'] ?? '');
+    $email = trim($_POST['email'] ?? '');
+    $password = $_POST['password'] ?? '';
+    $role = $_POST['role'] ?? '';
+
+    if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+        $errors[] = 'Invalid email address';
+    }
+
+    if (!preg_match('/^(?=.*[0-9])(?=.*[!@#$%^&*])[A-Za-z0-9!@#$%^&*]{8,}$/', $password)) {
+        $errors[] = 'Password must be at least 8 characters long and include a number and a symbol';
+    }
+
+    if ($role !== 'freelancer' && $role !== 'client') {
+        $errors[] = 'Invalid role selected';
+    }
+
+    if (!$errors) {
+        $stmt = $mysqli->prepare('INSERT INTO users (name, email, password, role) VALUES (?, ?, ?, ?)');
+        $hash = password_hash($password, PASSWORD_DEFAULT);
+        $stmt->bind_param('ssss', $name, $email, $hash, $role);
+        if ($stmt->execute()) {
+            header('Location: login.php');
+            exit();
+        } else {
+            $errors[] = 'Registration failed';
+        }
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="style.css">
+    <title>Register</title>
+</head>
+<body>
+<header class="site-header">
+    <div class="logo">Freelancer Hub</div>
+</header>
+<div class="form-container">
+    <?php foreach ($errors as $error): ?>
+        <p class="error"><?php echo htmlspecialchars($error); ?></p>
+    <?php endforeach; ?>
+    <form method="post" action="">
+        <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($_SESSION['csrf_token']); ?>">
+        <label>Name: <input type="text" name="name" required></label>
+        <label>Email: <input type="email" name="email" required></label>
+        <label>Password: <input type="password" name="password" required></label>
+        <label>Role:
+            <select name="role">
+                <option value="freelancer">Freelancer</option>
+                <option value="client">Client</option>
+            </select>
+        </label>
+        <button type="submit">Register</button>
+    </form>
+    <p>Already have an account? <a href="login.php">Login here</a></p>
+</div>
+</body>
+</html>

--- a/users.sql
+++ b/users.sql
@@ -1,0 +1,7 @@
+CREATE TABLE users (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    email VARCHAR(255) NOT NULL UNIQUE,
+    password VARCHAR(255) NOT NULL,
+    role ENUM('freelancer','client') NOT NULL
+);


### PR DESCRIPTION
## Summary
- add secure login script with CSRF tokens, email validation, and session handling
- create registration page with password strength checks and hashing
- define database connection helper and users table schema; update home page links

## Testing
- `php -l login.php`
- `php -l register.php`
- `php -l db.php`
- `php -l profile.php`
- `php -l logout.php`


------
https://chatgpt.com/codex/tasks/task_e_689e6bd67cc4832aae7ec70e2b989ceb