### PR TITLE
Implement client-side auth demo and static navigation

### DIFF
--- a/about.html
+++ b/about.html
@@ -9,24 +9,28 @@
 <body>
     <header class="site-header">
     <div class="logo">Freelancer Hub</div>
-    <nav class="navigation">
+        <nav class="navigation">
       <ul>
-        <li><a href="index.html">Home</a></li>
-        <li><a href="about.html">About Us</a></li>
-        <li><a href="job-listings.html">Job Listings</a></li>
-        <li><a href="contact.html">Contact Us</a></li>
+        <li class="always"><a href="index.html">Home</a></li>
+        <li class="always"><a href="about.html">About Us</a></li>
+        <li class="always"><a href="job-listings.html">Job Listings</a></li>
+        <li class="always"><a href="contact.html">Contact Us</a></li>
 
+        <!-- visible only when NOT logged in -->
         <li class="guest-only"><a href="login.html">Login</a></li>
-        <li class="guest-only"><a class="cta btn" href="register.html">Register</a></li>
+        <li class="guest-only"><a href="register.html" class="cta btn">Register</a></li>
 
-        <li class="auth-only for-freelancer"><a href="saved.html">Saved Jobs</a></li>
-        <li class="auth-only for-freelancer"><a href="applications.html">My Applications</a></li>
+        <!-- visible only when logged in, any role -->
+        <li class="auth-only" data-roles="any"><a href="profile.html">Profile</a></li>
+        <li class="auth-only" data-roles="any"><a href="logout.html">Logout</a></li>
 
-        <li class="auth-only for-client"><a href="post-job.html">Post a Job</a></li>
-        <li class="auth-only for-client"><a href="my-jobs.html">My Jobs</a></li>
+        <!-- visible only when logged in as freelancer -->
+        <li class="auth-only" data-roles="freelancer"><a href="saved-jobs.html">Saved Jobs</a></li>
+        <li class="auth-only" data-roles="freelancer"><a href="my-applications.html">My Applications</a></li>
 
-        <li class="auth-only"><a href="profile.html">Profile</a></li>
-        <li class="auth-only"><a href="logout.html">Logout</a></li>
+        <!-- visible only when logged in as client -->
+        <li class="auth-only" data-roles="client"><a href="post-job.html">Post a Job</a></li>
+        <li class="auth-only" data-roles="client"><a href="my-jobs.html">My Jobs</a></li>
       </ul>
     </nav>
   </header>
@@ -53,6 +57,7 @@
         </div>
         <p class="disclaimer">This website is for a class assignment and not for commercial purposes.</p>
     </footer>
+<script src="assets/js/auth-demo.js"></script>
 <script src="assets/js/app.js"></script>
 </body>
 </html>

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -57,8 +57,8 @@
       case 'profile.html': return controllerProfile();
       case 'job-listings.html': return controllerListings();
       case 'job-details.html': return controllerJobDetails();
-      case 'saved.html': return controllerSaved();
-      case 'applications.html': return controllerApplications();
+      case 'saved-jobs.html': return controllerSaved();
+      case 'my-applications.html': return controllerApplications();
       case 'post-job.html': return controllerPostJob();
       case 'my-jobs.html': return controllerMyJobs();
     }
@@ -118,8 +118,8 @@
       const newest = jobs.filter(j=>j.status==='open').sort((a,b)=>new Date(b.createdAt)-new Date(a.createdAt)).slice(0,3);
       panels.innerHTML = `
         <div class="cards">
-          <div class="card"><a href="saved.html" class="btn">Saved Jobs</a></div>
-          <div class="card"><a href="applications.html" class="btn">My Applications</a></div>
+          <div class="card"><a href="saved-jobs.html" class="btn">Saved Jobs</a></div>
+          <div class="card"><a href="my-applications.html" class="btn">My Applications</a></div>
         </div>
         <h2 style="margin-top:1.5rem;">Newest Jobs</h2>
         <ul>

--- a/assets/js/auth-demo.js
+++ b/assets/js/auth-demo.js
@@ -1,0 +1,93 @@
+(function () {
+  const KEY = 'fh_user';
+
+  const getUser = () => {
+    try { return JSON.parse(localStorage.getItem(KEY)); } catch { return null; }
+  };
+  const setUser = (u) => localStorage.setItem(KEY, JSON.stringify(u));
+  const clearUser = () => localStorage.removeItem(KEY);
+
+  function updateNav() {
+    const u = getUser();
+    const authed = !!u;
+
+    document.querySelectorAll('.guest-only').forEach(el => { el.hidden = authed; });
+
+    document.querySelectorAll('.auth-only').forEach(el => {
+      if (!authed) { el.hidden = true; return; }
+      const roles = (el.dataset.roles || 'any')
+        .split(',')
+        .map(s => s.trim().toLowerCase());
+      el.hidden = !(roles.includes('any') || roles.includes((u.user_type || '').toLowerCase()));
+    });
+  }
+
+  function onLoginPage() {
+    const form = document.querySelector('form');
+    if (!form) return;
+    form.addEventListener('submit', (e) => {
+      e.preventDefault();
+      const email = (document.getElementById('email')?.value || '').trim();
+      const pwd = document.getElementById('password')?.value || '';
+      const userType = document.querySelector('input[name="user_type"]:checked')?.value || 'freelancer';
+
+      const errors = [];
+      if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) errors.push('Please enter a valid email.');
+      if (!pwd) errors.push('Password is required.');
+
+      const box = document.querySelector('.error-list'); if (box) box.innerHTML = '';
+      if (errors.length) { if (box) box.innerHTML = errors.map(m=>`<p class="error">${m}</p>`).join(''); return; }
+
+      setUser({ email, user_type: userType });
+      updateNav();
+      window.location.href = 'profile.html';
+    });
+  }
+
+  function onRegisterPage() {
+    const form = document.querySelector('form');
+    if (!form) return;
+    form.addEventListener('submit', (e) => {
+      e.preventDefault();
+      const email = (document.getElementById('email')?.value || '').trim();
+      const pw = document.getElementById('password')?.value || '';
+      const cpw = document.getElementById('confirm_password')?.value || '';
+      const userType = document.querySelector('input[name="user_type"]:checked')?.value || 'freelancer';
+
+      const errors = [];
+      if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) errors.push('Please enter a valid email.');
+      if (!pw || !cpw) errors.push('Password and confirm password are required.');
+      if (pw !== cpw) errors.push('Passwords do not match.');
+
+      const box = document.querySelector('.error-list'); if (box) box.innerHTML = '';
+      if (errors.length) { if (box) box.innerHTML = errors.map(m=>`<p class="error">${m}</p>`).join(''); return; }
+
+      setUser({ email, user_type: userType });
+      updateNav();
+      window.location.href = 'profile.html';
+    });
+  }
+
+  function onProfilePage() {
+    const u = getUser();
+    if (!u) { window.location.replace('login.html'); return; }
+    const target = document.getElementById('welcome');
+    if (target) target.textContent = `Welcome, ${u.email} (${u.user_type})`;
+  }
+
+  function onLogoutPage() {
+    clearUser();
+    updateNav();
+    window.location.replace('index.html');
+  }
+
+  function route() {
+    const page = (location.pathname.split('/').pop() || '').toLowerCase();
+    if (page.includes('login.html')) onLoginPage();
+    else if (page.includes('register.html')) onRegisterPage();
+    else if (page.includes('profile.html')) onProfilePage();
+    else if (page.includes('logout.html')) onLogoutPage();
+  }
+
+  document.addEventListener('DOMContentLoaded', () => { updateNav(); route(); });
+})();

--- a/contact.html
+++ b/contact.html
@@ -9,24 +9,28 @@
 <body>
     <header class="site-header">
     <div class="logo">Freelancer Hub</div>
-    <nav class="navigation">
+        <nav class="navigation">
       <ul>
-        <li><a href="index.html">Home</a></li>
-        <li><a href="about.html">About Us</a></li>
-        <li><a href="job-listings.html">Job Listings</a></li>
-        <li><a href="contact.html">Contact Us</a></li>
+        <li class="always"><a href="index.html">Home</a></li>
+        <li class="always"><a href="about.html">About Us</a></li>
+        <li class="always"><a href="job-listings.html">Job Listings</a></li>
+        <li class="always"><a href="contact.html">Contact Us</a></li>
 
+        <!-- visible only when NOT logged in -->
         <li class="guest-only"><a href="login.html">Login</a></li>
-        <li class="guest-only"><a class="cta btn" href="register.html">Register</a></li>
+        <li class="guest-only"><a href="register.html" class="cta btn">Register</a></li>
 
-        <li class="auth-only for-freelancer"><a href="saved.html">Saved Jobs</a></li>
-        <li class="auth-only for-freelancer"><a href="applications.html">My Applications</a></li>
+        <!-- visible only when logged in, any role -->
+        <li class="auth-only" data-roles="any"><a href="profile.html">Profile</a></li>
+        <li class="auth-only" data-roles="any"><a href="logout.html">Logout</a></li>
 
-        <li class="auth-only for-client"><a href="post-job.html">Post a Job</a></li>
-        <li class="auth-only for-client"><a href="my-jobs.html">My Jobs</a></li>
+        <!-- visible only when logged in as freelancer -->
+        <li class="auth-only" data-roles="freelancer"><a href="saved-jobs.html">Saved Jobs</a></li>
+        <li class="auth-only" data-roles="freelancer"><a href="my-applications.html">My Applications</a></li>
 
-        <li class="auth-only"><a href="profile.html">Profile</a></li>
-        <li class="auth-only"><a href="logout.html">Logout</a></li>
+        <!-- visible only when logged in as client -->
+        <li class="auth-only" data-roles="client"><a href="post-job.html">Post a Job</a></li>
+        <li class="auth-only" data-roles="client"><a href="my-jobs.html">My Jobs</a></li>
       </ul>
     </nav>
   </header>
@@ -69,6 +73,7 @@
             e.target.reset();
         });
     </script>
+<script src="assets/js/auth-demo.js"></script>
 <script src="assets/js/app.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -11,24 +11,28 @@
     <!-- Header with navigation and call-to-action button -->
     <header class="site-header">
     <div class="logo">Freelancer Hub</div>
-    <nav class="navigation">
+        <nav class="navigation">
       <ul>
-        <li><a href="index.html">Home</a></li>
-        <li><a href="about.html">About Us</a></li>
-        <li><a href="job-listings.html">Job Listings</a></li>
-        <li><a href="contact.html">Contact Us</a></li>
+        <li class="always"><a href="index.html">Home</a></li>
+        <li class="always"><a href="about.html">About Us</a></li>
+        <li class="always"><a href="job-listings.html">Job Listings</a></li>
+        <li class="always"><a href="contact.html">Contact Us</a></li>
 
+        <!-- visible only when NOT logged in -->
         <li class="guest-only"><a href="login.html">Login</a></li>
-        <li class="guest-only"><a class="cta btn" href="register.html">Register</a></li>
+        <li class="guest-only"><a href="register.html" class="cta btn">Register</a></li>
 
-        <li class="auth-only for-freelancer"><a href="saved.html">Saved Jobs</a></li>
-        <li class="auth-only for-freelancer"><a href="applications.html">My Applications</a></li>
+        <!-- visible only when logged in, any role -->
+        <li class="auth-only" data-roles="any"><a href="profile.html">Profile</a></li>
+        <li class="auth-only" data-roles="any"><a href="logout.html">Logout</a></li>
 
-        <li class="auth-only for-client"><a href="post-job.html">Post a Job</a></li>
-        <li class="auth-only for-client"><a href="my-jobs.html">My Jobs</a></li>
+        <!-- visible only when logged in as freelancer -->
+        <li class="auth-only" data-roles="freelancer"><a href="saved-jobs.html">Saved Jobs</a></li>
+        <li class="auth-only" data-roles="freelancer"><a href="my-applications.html">My Applications</a></li>
 
-        <li class="auth-only"><a href="profile.html">Profile</a></li>
-        <li class="auth-only"><a href="logout.html">Logout</a></li>
+        <!-- visible only when logged in as client -->
+        <li class="auth-only" data-roles="client"><a href="post-job.html">Post a Job</a></li>
+        <li class="auth-only" data-roles="client"><a href="my-jobs.html">My Jobs</a></li>
       </ul>
     </nav>
   </header>
@@ -97,6 +101,7 @@
         <p class="disclaimer">This website is for a class assignment and not for commercial purposes.</p>
     </footer>
     
+<script src="assets/js/auth-demo.js"></script>
 <script src="assets/js/app.js"></script>
 </body>
 </html>

--- a/job-details.html
+++ b/job-details.html
@@ -9,24 +9,28 @@
 <body>
     <header class="site-header">
     <div class="logo">Freelancer Hub</div>
-    <nav class="navigation">
+        <nav class="navigation">
       <ul>
-        <li><a href="index.html">Home</a></li>
-        <li><a href="about.html">About Us</a></li>
-        <li><a href="job-listings.html">Job Listings</a></li>
-        <li><a href="contact.html">Contact Us</a></li>
+        <li class="always"><a href="index.html">Home</a></li>
+        <li class="always"><a href="about.html">About Us</a></li>
+        <li class="always"><a href="job-listings.html">Job Listings</a></li>
+        <li class="always"><a href="contact.html">Contact Us</a></li>
 
+        <!-- visible only when NOT logged in -->
         <li class="guest-only"><a href="login.html">Login</a></li>
-        <li class="guest-only"><a class="cta btn" href="register.html">Register</a></li>
+        <li class="guest-only"><a href="register.html" class="cta btn">Register</a></li>
 
-        <li class="auth-only for-freelancer"><a href="saved.html">Saved Jobs</a></li>
-        <li class="auth-only for-freelancer"><a href="applications.html">My Applications</a></li>
+        <!-- visible only when logged in, any role -->
+        <li class="auth-only" data-roles="any"><a href="profile.html">Profile</a></li>
+        <li class="auth-only" data-roles="any"><a href="logout.html">Logout</a></li>
 
-        <li class="auth-only for-client"><a href="post-job.html">Post a Job</a></li>
-        <li class="auth-only for-client"><a href="my-jobs.html">My Jobs</a></li>
+        <!-- visible only when logged in as freelancer -->
+        <li class="auth-only" data-roles="freelancer"><a href="saved-jobs.html">Saved Jobs</a></li>
+        <li class="auth-only" data-roles="freelancer"><a href="my-applications.html">My Applications</a></li>
 
-        <li class="auth-only"><a href="profile.html">Profile</a></li>
-        <li class="auth-only"><a href="logout.html">Logout</a></li>
+        <!-- visible only when logged in as client -->
+        <li class="auth-only" data-roles="client"><a href="post-job.html">Post a Job</a></li>
+        <li class="auth-only" data-roles="client"><a href="my-jobs.html">My Jobs</a></li>
       </ul>
     </nav>
   </header>
@@ -34,7 +38,7 @@
 <section style="max-width:800px;margin:2rem auto;padding:0 1rem;">
   <div id="job-detail"></div>
   <div class="error-list" role="alert" aria-live="polite"></div>
-  <div id="apply-box" class="auth-only for-freelancer" style="margin-top:1rem;"></div>
+  <div id="apply-box" class="auth-only" data-roles="freelancer" style="margin-top:1rem;"></div>
 </section>
 </main>
     <footer class="site-footer">
@@ -48,6 +52,7 @@
         </div>
         <p class="disclaimer">This website is for a class assignment and not for commercial purposes.</p>
     </footer>
+<script src="assets/js/auth-demo.js"></script>
 <script src="assets/js/app.js"></script>
 </body>
 </html>

--- a/job-listings.html
+++ b/job-listings.html
@@ -9,24 +9,28 @@
 <body>
     <header class="site-header">
     <div class="logo">Freelancer Hub</div>
-    <nav class="navigation">
+        <nav class="navigation">
       <ul>
-        <li><a href="index.html">Home</a></li>
-        <li><a href="about.html">About Us</a></li>
-        <li><a href="job-listings.html">Job Listings</a></li>
-        <li><a href="contact.html">Contact Us</a></li>
+        <li class="always"><a href="index.html">Home</a></li>
+        <li class="always"><a href="about.html">About Us</a></li>
+        <li class="always"><a href="job-listings.html">Job Listings</a></li>
+        <li class="always"><a href="contact.html">Contact Us</a></li>
 
+        <!-- visible only when NOT logged in -->
         <li class="guest-only"><a href="login.html">Login</a></li>
-        <li class="guest-only"><a class="cta btn" href="register.html">Register</a></li>
+        <li class="guest-only"><a href="register.html" class="cta btn">Register</a></li>
 
-        <li class="auth-only for-freelancer"><a href="saved.html">Saved Jobs</a></li>
-        <li class="auth-only for-freelancer"><a href="applications.html">My Applications</a></li>
+        <!-- visible only when logged in, any role -->
+        <li class="auth-only" data-roles="any"><a href="profile.html">Profile</a></li>
+        <li class="auth-only" data-roles="any"><a href="logout.html">Logout</a></li>
 
-        <li class="auth-only for-client"><a href="post-job.html">Post a Job</a></li>
-        <li class="auth-only for-client"><a href="my-jobs.html">My Jobs</a></li>
+        <!-- visible only when logged in as freelancer -->
+        <li class="auth-only" data-roles="freelancer"><a href="saved-jobs.html">Saved Jobs</a></li>
+        <li class="auth-only" data-roles="freelancer"><a href="my-applications.html">My Applications</a></li>
 
-        <li class="auth-only"><a href="profile.html">Profile</a></li>
-        <li class="auth-only"><a href="logout.html">Logout</a></li>
+        <!-- visible only when logged in as client -->
+        <li class="auth-only" data-roles="client"><a href="post-job.html">Post a Job</a></li>
+        <li class="auth-only" data-roles="client"><a href="my-jobs.html">My Jobs</a></li>
       </ul>
     </nav>
   </header>
@@ -65,6 +69,7 @@
         </div>
         <p class="disclaimer">This website is for a class assignment and not for commercial purposes.</p>
     </footer>
+<script src="assets/js/auth-demo.js"></script>
 <script src="assets/js/app.js"></script>
 </body>
 </html>

--- a/login.html
+++ b/login.html
@@ -9,24 +9,28 @@
 <body>
   <header class="site-header">
     <div class="logo">Freelancer Hub</div>
-    <nav class="navigation">
+        <nav class="navigation">
       <ul>
-        <li><a href="index.html">Home</a></li>
-        <li><a href="about.html">About Us</a></li>
-        <li><a href="job-listings.html">Job Listings</a></li>
-        <li><a href="contact.html">Contact Us</a></li>
+        <li class="always"><a href="index.html">Home</a></li>
+        <li class="always"><a href="about.html">About Us</a></li>
+        <li class="always"><a href="job-listings.html">Job Listings</a></li>
+        <li class="always"><a href="contact.html">Contact Us</a></li>
 
+        <!-- visible only when NOT logged in -->
         <li class="guest-only"><a href="login.html">Login</a></li>
-        <li class="guest-only"><a class="cta btn" href="register.html">Register</a></li>
+        <li class="guest-only"><a href="register.html" class="cta btn">Register</a></li>
 
-        <li class="auth-only for-freelancer"><a href="saved.html">Saved Jobs</a></li>
-        <li class="auth-only for-freelancer"><a href="applications.html">My Applications</a></li>
+        <!-- visible only when logged in, any role -->
+        <li class="auth-only" data-roles="any"><a href="profile.html">Profile</a></li>
+        <li class="auth-only" data-roles="any"><a href="logout.html">Logout</a></li>
 
-        <li class="auth-only for-client"><a href="post-job.html">Post a Job</a></li>
-        <li class="auth-only for-client"><a href="my-jobs.html">My Jobs</a></li>
+        <!-- visible only when logged in as freelancer -->
+        <li class="auth-only" data-roles="freelancer"><a href="saved-jobs.html">Saved Jobs</a></li>
+        <li class="auth-only" data-roles="freelancer"><a href="my-applications.html">My Applications</a></li>
 
-        <li class="auth-only"><a href="profile.html">Profile</a></li>
-        <li class="auth-only"><a href="logout.html">Logout</a></li>
+        <!-- visible only when logged in as client -->
+        <li class="auth-only" data-roles="client"><a href="post-job.html">Post a Job</a></li>
+        <li class="auth-only" data-roles="client"><a href="my-jobs.html">My Jobs</a></li>
       </ul>
     </nav>
   </header>
@@ -63,6 +67,7 @@
     </div>
     <p class="disclaimer">This website is for a class assignment and not for commercial purposes.</p>
   </footer>
+<script src="assets/js/auth-demo.js"></script>
 <script src="assets/js/app.js"></script>
 </body>
 </html>

--- a/logout.html
+++ b/logout.html
@@ -9,24 +9,28 @@
 <body>
   <header class="site-header">
     <div class="logo">Freelancer Hub</div>
-    <nav class="navigation">
+        <nav class="navigation">
       <ul>
-        <li><a href="index.html">Home</a></li>
-        <li><a href="about.html">About Us</a></li>
-        <li><a href="job-listings.html">Job Listings</a></li>
-        <li><a href="contact.html">Contact Us</a></li>
+        <li class="always"><a href="index.html">Home</a></li>
+        <li class="always"><a href="about.html">About Us</a></li>
+        <li class="always"><a href="job-listings.html">Job Listings</a></li>
+        <li class="always"><a href="contact.html">Contact Us</a></li>
 
+        <!-- visible only when NOT logged in -->
         <li class="guest-only"><a href="login.html">Login</a></li>
-        <li class="guest-only"><a class="cta btn" href="register.html">Register</a></li>
+        <li class="guest-only"><a href="register.html" class="cta btn">Register</a></li>
 
-        <li class="auth-only for-freelancer"><a href="saved.html">Saved Jobs</a></li>
-        <li class="auth-only for-freelancer"><a href="applications.html">My Applications</a></li>
+        <!-- visible only when logged in, any role -->
+        <li class="auth-only" data-roles="any"><a href="profile.html">Profile</a></li>
+        <li class="auth-only" data-roles="any"><a href="logout.html">Logout</a></li>
 
-        <li class="auth-only for-client"><a href="post-job.html">Post a Job</a></li>
-        <li class="auth-only for-client"><a href="my-jobs.html">My Jobs</a></li>
+        <!-- visible only when logged in as freelancer -->
+        <li class="auth-only" data-roles="freelancer"><a href="saved-jobs.html">Saved Jobs</a></li>
+        <li class="auth-only" data-roles="freelancer"><a href="my-applications.html">My Applications</a></li>
 
-        <li class="auth-only"><a href="profile.html">Profile</a></li>
-        <li class="auth-only"><a href="logout.html">Logout</a></li>
+        <!-- visible only when logged in as client -->
+        <li class="auth-only" data-roles="client"><a href="post-job.html">Post a Job</a></li>
+        <li class="auth-only" data-roles="client"><a href="my-jobs.html">My Jobs</a></li>
       </ul>
     </nav>
   </header>
@@ -42,6 +46,7 @@
     </div>
     <p class="disclaimer">This website is for a class assignment and not for commercial purposes.</p>
   </footer>
+<script src="assets/js/auth-demo.js"></script>
 <script src="assets/js/app.js"></script>
 </body>
 </html>

--- a/my-applications.html
+++ b/my-applications.html
@@ -9,24 +9,28 @@
 <body>
   <header class="site-header">
     <div class="logo">Freelancer Hub</div>
-    <nav class="navigation">
+        <nav class="navigation">
       <ul>
-        <li><a href="index.html">Home</a></li>
-        <li><a href="about.html">About Us</a></li>
-        <li><a href="job-listings.html">Job Listings</a></li>
-        <li><a href="contact.html">Contact Us</a></li>
+        <li class="always"><a href="index.html">Home</a></li>
+        <li class="always"><a href="about.html">About Us</a></li>
+        <li class="always"><a href="job-listings.html">Job Listings</a></li>
+        <li class="always"><a href="contact.html">Contact Us</a></li>
 
+        <!-- visible only when NOT logged in -->
         <li class="guest-only"><a href="login.html">Login</a></li>
-        <li class="guest-only"><a class="cta btn" href="register.html">Register</a></li>
+        <li class="guest-only"><a href="register.html" class="cta btn">Register</a></li>
 
-        <li class="auth-only for-freelancer"><a href="saved.html">Saved Jobs</a></li>
-        <li class="auth-only for-freelancer"><a href="applications.html">My Applications</a></li>
+        <!-- visible only when logged in, any role -->
+        <li class="auth-only" data-roles="any"><a href="profile.html">Profile</a></li>
+        <li class="auth-only" data-roles="any"><a href="logout.html">Logout</a></li>
 
-        <li class="auth-only for-client"><a href="post-job.html">Post a Job</a></li>
-        <li class="auth-only for-client"><a href="my-jobs.html">My Jobs</a></li>
+        <!-- visible only when logged in as freelancer -->
+        <li class="auth-only" data-roles="freelancer"><a href="saved-jobs.html">Saved Jobs</a></li>
+        <li class="auth-only" data-roles="freelancer"><a href="my-applications.html">My Applications</a></li>
 
-        <li class="auth-only"><a href="profile.html">Profile</a></li>
-        <li class="auth-only"><a href="logout.html">Logout</a></li>
+        <!-- visible only when logged in as client -->
+        <li class="auth-only" data-roles="client"><a href="post-job.html">Post a Job</a></li>
+        <li class="auth-only" data-roles="client"><a href="my-jobs.html">My Jobs</a></li>
       </ul>
     </nav>
   </header>
@@ -47,6 +51,7 @@
     </div>
     <p class="disclaimer">This website is for a class assignment and not for commercial purposes.</p>
   </footer>
+<script src="assets/js/auth-demo.js"></script>
 <script src="assets/js/app.js"></script>
 </body>
 </html>

--- a/my-jobs.html
+++ b/my-jobs.html
@@ -9,24 +9,28 @@
 <body>
   <header class="site-header">
     <div class="logo">Freelancer Hub</div>
-    <nav class="navigation">
+        <nav class="navigation">
       <ul>
-        <li><a href="index.html">Home</a></li>
-        <li><a href="about.html">About Us</a></li>
-        <li><a href="job-listings.html">Job Listings</a></li>
-        <li><a href="contact.html">Contact Us</a></li>
+        <li class="always"><a href="index.html">Home</a></li>
+        <li class="always"><a href="about.html">About Us</a></li>
+        <li class="always"><a href="job-listings.html">Job Listings</a></li>
+        <li class="always"><a href="contact.html">Contact Us</a></li>
 
+        <!-- visible only when NOT logged in -->
         <li class="guest-only"><a href="login.html">Login</a></li>
-        <li class="guest-only"><a class="cta btn" href="register.html">Register</a></li>
+        <li class="guest-only"><a href="register.html" class="cta btn">Register</a></li>
 
-        <li class="auth-only for-freelancer"><a href="saved.html">Saved Jobs</a></li>
-        <li class="auth-only for-freelancer"><a href="applications.html">My Applications</a></li>
+        <!-- visible only when logged in, any role -->
+        <li class="auth-only" data-roles="any"><a href="profile.html">Profile</a></li>
+        <li class="auth-only" data-roles="any"><a href="logout.html">Logout</a></li>
 
-        <li class="auth-only for-client"><a href="post-job.html">Post a Job</a></li>
-        <li class="auth-only for-client"><a href="my-jobs.html">My Jobs</a></li>
+        <!-- visible only when logged in as freelancer -->
+        <li class="auth-only" data-roles="freelancer"><a href="saved-jobs.html">Saved Jobs</a></li>
+        <li class="auth-only" data-roles="freelancer"><a href="my-applications.html">My Applications</a></li>
 
-        <li class="auth-only"><a href="profile.html">Profile</a></li>
-        <li class="auth-only"><a href="logout.html">Logout</a></li>
+        <!-- visible only when logged in as client -->
+        <li class="auth-only" data-roles="client"><a href="post-job.html">Post a Job</a></li>
+        <li class="auth-only" data-roles="client"><a href="my-jobs.html">My Jobs</a></li>
       </ul>
     </nav>
   </header>
@@ -47,6 +51,7 @@
     </div>
     <p class="disclaimer">This website is for a class assignment and not for commercial purposes.</p>
   </footer>
+<script src="assets/js/auth-demo.js"></script>
 <script src="assets/js/app.js"></script>
 </body>
 </html>

--- a/post-job.html
+++ b/post-job.html
@@ -9,24 +9,28 @@
 <body>
   <header class="site-header">
     <div class="logo">Freelancer Hub</div>
-    <nav class="navigation">
+        <nav class="navigation">
       <ul>
-        <li><a href="index.html">Home</a></li>
-        <li><a href="about.html">About Us</a></li>
-        <li><a href="job-listings.html">Job Listings</a></li>
-        <li><a href="contact.html">Contact Us</a></li>
+        <li class="always"><a href="index.html">Home</a></li>
+        <li class="always"><a href="about.html">About Us</a></li>
+        <li class="always"><a href="job-listings.html">Job Listings</a></li>
+        <li class="always"><a href="contact.html">Contact Us</a></li>
 
+        <!-- visible only when NOT logged in -->
         <li class="guest-only"><a href="login.html">Login</a></li>
-        <li class="guest-only"><a class="cta btn" href="register.html">Register</a></li>
+        <li class="guest-only"><a href="register.html" class="cta btn">Register</a></li>
 
-        <li class="auth-only for-freelancer"><a href="saved.html">Saved Jobs</a></li>
-        <li class="auth-only for-freelancer"><a href="applications.html">My Applications</a></li>
+        <!-- visible only when logged in, any role -->
+        <li class="auth-only" data-roles="any"><a href="profile.html">Profile</a></li>
+        <li class="auth-only" data-roles="any"><a href="logout.html">Logout</a></li>
 
-        <li class="auth-only for-client"><a href="post-job.html">Post a Job</a></li>
-        <li class="auth-only for-client"><a href="my-jobs.html">My Jobs</a></li>
+        <!-- visible only when logged in as freelancer -->
+        <li class="auth-only" data-roles="freelancer"><a href="saved-jobs.html">Saved Jobs</a></li>
+        <li class="auth-only" data-roles="freelancer"><a href="my-applications.html">My Applications</a></li>
 
-        <li class="auth-only"><a href="profile.html">Profile</a></li>
-        <li class="auth-only"><a href="logout.html">Logout</a></li>
+        <!-- visible only when logged in as client -->
+        <li class="auth-only" data-roles="client"><a href="post-job.html">Post a Job</a></li>
+        <li class="auth-only" data-roles="client"><a href="my-jobs.html">My Jobs</a></li>
       </ul>
     </nav>
   </header>
@@ -61,6 +65,7 @@
     </div>
     <p class="disclaimer">This website is for a class assignment and not for commercial purposes.</p>
   </footer>
+<script src="assets/js/auth-demo.js"></script>
 <script src="assets/js/app.js"></script>
 </body>
 </html>

--- a/profile.html
+++ b/profile.html
@@ -9,24 +9,28 @@
 <body>
   <header class="site-header">
     <div class="logo">Freelancer Hub</div>
-    <nav class="navigation">
+        <nav class="navigation">
       <ul>
-        <li><a href="index.html">Home</a></li>
-        <li><a href="about.html">About Us</a></li>
-        <li><a href="job-listings.html">Job Listings</a></li>
-        <li><a href="contact.html">Contact Us</a></li>
+        <li class="always"><a href="index.html">Home</a></li>
+        <li class="always"><a href="about.html">About Us</a></li>
+        <li class="always"><a href="job-listings.html">Job Listings</a></li>
+        <li class="always"><a href="contact.html">Contact Us</a></li>
 
+        <!-- visible only when NOT logged in -->
         <li class="guest-only"><a href="login.html">Login</a></li>
-        <li class="guest-only"><a class="cta btn" href="register.html">Register</a></li>
+        <li class="guest-only"><a href="register.html" class="cta btn">Register</a></li>
 
-        <li class="auth-only for-freelancer"><a href="saved.html">Saved Jobs</a></li>
-        <li class="auth-only for-freelancer"><a href="applications.html">My Applications</a></li>
+        <!-- visible only when logged in, any role -->
+        <li class="auth-only" data-roles="any"><a href="profile.html">Profile</a></li>
+        <li class="auth-only" data-roles="any"><a href="logout.html">Logout</a></li>
 
-        <li class="auth-only for-client"><a href="post-job.html">Post a Job</a></li>
-        <li class="auth-only for-client"><a href="my-jobs.html">My Jobs</a></li>
+        <!-- visible only when logged in as freelancer -->
+        <li class="auth-only" data-roles="freelancer"><a href="saved-jobs.html">Saved Jobs</a></li>
+        <li class="auth-only" data-roles="freelancer"><a href="my-applications.html">My Applications</a></li>
 
-        <li class="auth-only"><a href="profile.html">Profile</a></li>
-        <li class="auth-only"><a href="logout.html">Logout</a></li>
+        <!-- visible only when logged in as client -->
+        <li class="auth-only" data-roles="client"><a href="post-job.html">Post a Job</a></li>
+        <li class="auth-only" data-roles="client"><a href="my-jobs.html">My Jobs</a></li>
       </ul>
     </nav>
   </header>
@@ -47,6 +51,7 @@
     </div>
     <p class="disclaimer">This website is for a class assignment and not for commercial purposes.</p>
   </footer>
+<script src="assets/js/auth-demo.js"></script>
 <script src="assets/js/app.js"></script>
 </body>
 </html>

--- a/register.html
+++ b/register.html
@@ -9,24 +9,28 @@
 <body>
   <header class="site-header">
     <div class="logo">Freelancer Hub</div>
-    <nav class="navigation">
+        <nav class="navigation">
       <ul>
-        <li><a href="index.html">Home</a></li>
-        <li><a href="about.html">About Us</a></li>
-        <li><a href="job-listings.html">Job Listings</a></li>
-        <li><a href="contact.html">Contact Us</a></li>
+        <li class="always"><a href="index.html">Home</a></li>
+        <li class="always"><a href="about.html">About Us</a></li>
+        <li class="always"><a href="job-listings.html">Job Listings</a></li>
+        <li class="always"><a href="contact.html">Contact Us</a></li>
 
+        <!-- visible only when NOT logged in -->
         <li class="guest-only"><a href="login.html">Login</a></li>
-        <li class="guest-only"><a class="cta btn" href="register.html">Register</a></li>
+        <li class="guest-only"><a href="register.html" class="cta btn">Register</a></li>
 
-        <li class="auth-only for-freelancer"><a href="saved.html">Saved Jobs</a></li>
-        <li class="auth-only for-freelancer"><a href="applications.html">My Applications</a></li>
+        <!-- visible only when logged in, any role -->
+        <li class="auth-only" data-roles="any"><a href="profile.html">Profile</a></li>
+        <li class="auth-only" data-roles="any"><a href="logout.html">Logout</a></li>
 
-        <li class="auth-only for-client"><a href="post-job.html">Post a Job</a></li>
-        <li class="auth-only for-client"><a href="my-jobs.html">My Jobs</a></li>
+        <!-- visible only when logged in as freelancer -->
+        <li class="auth-only" data-roles="freelancer"><a href="saved-jobs.html">Saved Jobs</a></li>
+        <li class="auth-only" data-roles="freelancer"><a href="my-applications.html">My Applications</a></li>
 
-        <li class="auth-only"><a href="profile.html">Profile</a></li>
-        <li class="auth-only"><a href="logout.html">Logout</a></li>
+        <!-- visible only when logged in as client -->
+        <li class="auth-only" data-roles="client"><a href="post-job.html">Post a Job</a></li>
+        <li class="auth-only" data-roles="client"><a href="my-jobs.html">My Jobs</a></li>
       </ul>
     </nav>
   </header>
@@ -66,6 +70,7 @@
     </div>
     <p class="disclaimer">This website is for a class assignment and not for commercial purposes.</p>
   </footer>
+<script src="assets/js/auth-demo.js"></script>
 <script src="assets/js/app.js"></script>
 </body>
 </html>

--- a/saved-jobs.html
+++ b/saved-jobs.html
@@ -9,24 +9,28 @@
 <body>
   <header class="site-header">
     <div class="logo">Freelancer Hub</div>
-    <nav class="navigation">
+        <nav class="navigation">
       <ul>
-        <li><a href="index.html">Home</a></li>
-        <li><a href="about.html">About Us</a></li>
-        <li><a href="job-listings.html">Job Listings</a></li>
-        <li><a href="contact.html">Contact Us</a></li>
+        <li class="always"><a href="index.html">Home</a></li>
+        <li class="always"><a href="about.html">About Us</a></li>
+        <li class="always"><a href="job-listings.html">Job Listings</a></li>
+        <li class="always"><a href="contact.html">Contact Us</a></li>
 
+        <!-- visible only when NOT logged in -->
         <li class="guest-only"><a href="login.html">Login</a></li>
-        <li class="guest-only"><a class="cta btn" href="register.html">Register</a></li>
+        <li class="guest-only"><a href="register.html" class="cta btn">Register</a></li>
 
-        <li class="auth-only for-freelancer"><a href="saved.html">Saved Jobs</a></li>
-        <li class="auth-only for-freelancer"><a href="applications.html">My Applications</a></li>
+        <!-- visible only when logged in, any role -->
+        <li class="auth-only" data-roles="any"><a href="profile.html">Profile</a></li>
+        <li class="auth-only" data-roles="any"><a href="logout.html">Logout</a></li>
 
-        <li class="auth-only for-client"><a href="post-job.html">Post a Job</a></li>
-        <li class="auth-only for-client"><a href="my-jobs.html">My Jobs</a></li>
+        <!-- visible only when logged in as freelancer -->
+        <li class="auth-only" data-roles="freelancer"><a href="saved-jobs.html">Saved Jobs</a></li>
+        <li class="auth-only" data-roles="freelancer"><a href="my-applications.html">My Applications</a></li>
 
-        <li class="auth-only"><a href="profile.html">Profile</a></li>
-        <li class="auth-only"><a href="logout.html">Logout</a></li>
+        <!-- visible only when logged in as client -->
+        <li class="auth-only" data-roles="client"><a href="post-job.html">Post a Job</a></li>
+        <li class="auth-only" data-roles="client"><a href="my-jobs.html">My Jobs</a></li>
       </ul>
     </nav>
   </header>
@@ -47,6 +51,7 @@
     </div>
     <p class="disclaimer">This website is for a class assignment and not for commercial purposes.</p>
   </footer>
+<script src="assets/js/auth-demo.js"></script>
 <script src="assets/js/app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Implement localStorage-based fake authentication demo
- Replace site navigation with role-aware static HTML links
- Rename saved and applications pages and include demo script across pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a04449d464832aafa76563823061f1