### PR TITLE
feat: add preview-aware router

### DIFF
--- a/assets/js/app-demo.js
+++ b/assets/js/app-demo.js
@@ -25,9 +25,9 @@
 
   const requireAuth = (role /* 'freelancer' | 'client' | undefined */) => {
     const u = currentUser();
-    if (!u) { location.replace('login.html'); return false; }
+    if (!u) { go('login.html'); return false; }
     if (role && (u.user_type || '').toLowerCase() !== role.toLowerCase()) {
-      location.replace('profile.html'); return false;
+      go('profile.html'); return false;
     }
     return true;
   };

--- a/post-job.html
+++ b/post-job.html
@@ -85,7 +85,7 @@
         salary: Number(document.getElementById('salary').value),
         clientEmail: u.email,
       });
-      location.href = 'my-jobs.html';
+      go('my-jobs.html');
     });
   });
 </script>


### PR DESCRIPTION
## Summary
- add preview-aware routing helpers and link rewriting
- use go() redirects across auth and app flows
- ensure post-job redirect is preview-safe

## Testing
- `npm test` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a049bb92f8832a85b78ffb8a40e99d