### PR TITLE
Add theme system and UI utilities

### DIFF
--- a/about.html
+++ b/about.html
@@ -5,6 +5,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>About Us - Freelancer Hub</title>
     <link rel="stylesheet" href="style.css" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link rel="icon" href="assets/favicon.svg" type="image/svg+xml">
+<link rel="manifest" href="assets/site.webmanifest">
+<link rel="stylesheet" href="assets/css/theme.css">
+<script src="https://unpkg.com/feather-icons"></script>
+<script>document.addEventListener('DOMContentLoaded', () => { if (window.feather) feather.replace(); });</script>
 </head>
 <body>
     <header class="site-header">
@@ -58,6 +65,7 @@
         <p class="disclaimer">This website is for a class assignment and not for commercial purposes.</p>
     </footer>
 <script src="assets/js/auth-demo.js"></script>
+<script src="assets/js/ui.js"></script>
 <script src="assets/js/app-demo.js"></script>
 </body>
 </html>

--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -1,0 +1,144 @@
+/* Theme system */
+:root {
+  --bg: #ffffff;
+  --surface: #f9fafb;
+  --text: #111827;
+  --muted: #6b7280;
+  --brand: #2563eb;
+  --brand-contrast: #ffffff;
+  --border: #e5e7eb;
+  --shadow-1: 0 1px 2px rgba(0,0,0,0.07);
+  --shadow-2: 0 4px 12px rgba(0,0,0,0.12);
+  --radius: 6px;
+  --radius-lg: 12px;
+  --gap: 1rem;
+  --speed-1: 150ms;
+  --speed-2: 250ms;
+  --easing: cubic-bezier(0.2,0.6,0.2,1);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #0b0d0f;
+    --surface: #1f2329;
+    --text: #f3f4f6;
+    --muted: #9ca3af;
+    --brand: #3b82f6;
+    --brand-contrast: #000000;
+    --border: #374151;
+    --shadow-1: 0 1px 2px rgba(0,0,0,0.6);
+    --shadow-2: 0 4px 12px rgba(0,0,0,0.8);
+  }
+}
+
+html[data-theme="dark"] {
+  --bg: #0b0d0f;
+  --surface: #1f2329;
+  --text: #f3f4f6;
+  --muted: #9ca3af;
+  --brand: #3b82f6;
+  --brand-contrast: #000000;
+  --border: #374151;
+  --shadow-1: 0 1px 2px rgba(0,0,0,0.6);
+  --shadow-2: 0 4px 12px rgba(0,0,0,0.8);
+}
+
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+  line-height: 1.6;
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  background: var(--surface);
+  z-index: 20;
+}
+.site-header.is-stuck {
+  box-shadow: var(--shadow-1);
+}
+
+.navigation ul { list-style: none; margin:0; padding:0; display:flex; gap:var(--gap); }
+.navigation a { text-decoration:none; color:var(--text); padding:0.25rem 0; }
+
+.menu-toggle { display:none; background:none; border:0; }
+.icon-btn { background:none; border:0; cursor:pointer; color:var(--text); }
+.theme-toggle { display:block; margin-left:auto; }
+@media (max-width: 768px) {
+  .navigation { display:none; position:absolute; top:100%; left:0; right:0; background:var(--surface); flex-direction:column; box-shadow:var(--shadow-1); }
+  .navigation.open { display:flex; animation:slide-down var(--speed-2) var(--easing); }
+  .menu-toggle { display:block; }
+}
+
+.filters { display:flex; flex-wrap:wrap; gap:var(--gap); margin:var(--gap) 0; }
+.filters input, .filters select { padding:0.5rem; border:1px solid var(--border); border-radius:var(--radius); }
+
+.btn {
+  position:relative;
+  overflow:hidden;
+  display:inline-block;
+  padding:0.6rem 1rem;
+  border-radius:var(--radius);
+  background:var(--brand);
+  color:var(--brand-contrast);
+  cursor:pointer;
+  border:1px solid transparent;
+  transition:background var(--speed-1) var(--easing), box-shadow var(--speed-1) var(--easing), transform var(--speed-1) var(--easing);
+}
+.btn:hover { box-shadow:var(--shadow-1); transform:translateY(-2px); }
+.btn:active { transform:translateY(0); }
+.btn.danger { background:#dc2626; color:#fff; }
+.btn.ghost { background:transparent; color:var(--text); border-color:var(--border); }
+
+.ripple {
+  position:absolute;
+  border-radius:50%;
+  transform:scale(0);
+  background:rgba(255,255,255,0.5);
+  animation:ripple var(--speed-1) linear;
+}
+@keyframes ripple {
+  to { transform:scale(4); opacity:0; }
+}
+
+.card {
+  background:var(--surface);
+  border:1px solid var(--border);
+  border-radius:var(--radius-lg);
+  box-shadow:var(--shadow-1);
+  transition:transform var(--speed-2) var(--easing), box-shadow var(--speed-2) var(--easing);
+}
+.card:hover { transform:translateY(-2px); box-shadow:var(--shadow-2); }
+
+.muted { color:var(--muted); }
+
+:focus-visible { outline:2px solid var(--brand); outline-offset:2px; }
+
+.toast-root { position:fixed; top:1rem; right:1rem; display:flex; flex-direction:column; gap:0.5rem; z-index:1000; }
+@media (max-width:600px) {
+  .toast-root { top:auto; bottom:0; right:0; left:0; }
+}
+.toast { padding:0.75rem 1rem; border-radius:var(--radius); background:var(--surface); color:var(--text); box-shadow:var(--shadow-1); }
+.toast.success { border-left:4px solid #16a34a; }
+.toast.error { border-left:4px solid #dc2626; }
+
+.modal-backdrop { position:fixed; inset:0; background:rgba(0,0,0,0.5); display:flex; align-items:center; justify-content:center; z-index:900; }
+.modal { background:var(--surface); border-radius:var(--radius-lg); box-shadow:var(--shadow-2); max-width:90%; width:400px; animation:scale-in var(--speed-2) var(--easing); }
+.modal-header, .modal-footer { padding:1rem; border-bottom:1px solid var(--border); }
+.modal-header { display:flex; justify-content:space-between; align-items:center; }
+.modal-body { padding:1rem; }
+.modal-footer { border-bottom:0; display:flex; justify-content:flex-end; gap:0.5rem; }
+
+.skeleton { background:var(--border); border-radius:var(--radius); height:1rem; margin:0.5rem 0; overflow:hidden; position:relative; }
+.skeleton::after { content:''; position:absolute; inset:0; background:linear-gradient(90deg, transparent, rgba(255,255,255,0.4), transparent); animation:skeleton-loading 1.2s infinite; }
+@keyframes skeleton-loading { from { transform:translateX(-100%);} to { transform:translateX(100%);} }
+
+@keyframes fade-in { from{opacity:0;} to{opacity:1;} }
+@keyframes slide-down { from{opacity:0; transform:translateY(-10px);} to{opacity:1; transform:translateY(0);} }
+@keyframes scale-in { from{opacity:0; transform:scale(0.95);} to{opacity:1; transform:scale(1);} }
+
+@media (prefers-reduced-motion: no-preference) {
+  * { transition: background-color var(--speed-2) var(--easing), color var(--speed-2) var(--easing), border-color var(--speed-2) var(--easing); }
+}

--- a/assets/favicon.svg
+++ b/assets/favicon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="12" fill="#2563eb"/>
+  <text x="50%" y="50%" font-size="36" text-anchor="middle" dominant-baseline="central" fill="#fff" font-family="Inter, Arial, sans-serif">FH</text>
+</svg>

--- a/assets/js/ui.js
+++ b/assets/js/ui.js
@@ -1,0 +1,134 @@
+(function(){
+  const UI = {};
+
+  // Toast notifications
+  UI.toast = function(msg, type='info') {
+    let root = document.getElementById('toast-root');
+    if(!root){
+      root = document.createElement('div');
+      root.id='toast-root';
+      root.className='toast-root';
+      root.setAttribute('aria-live','polite');
+      root.setAttribute('aria-atomic','true');
+      document.body.appendChild(root);
+    }
+    const t = document.createElement('div');
+    t.className = 'toast ' + type;
+    t.textContent = msg;
+    root.appendChild(t);
+    setTimeout(()=>{ t.remove(); },3000);
+  };
+
+  // Modal
+  UI.modal = function(opts){
+    const backdrop = document.createElement('div');
+    backdrop.className='modal-backdrop';
+    backdrop.setAttribute('data-modal','');
+    backdrop.innerHTML = `\n  <div class="modal" role="dialog" aria-modal="true" aria-labelledby="modal-title">\n    <div class="modal-header"><h3 id="modal-title">${opts.title||''}</h3><button class="icon-btn" aria-label="Close" data-close>&times;</button></div>\n    <div class="modal-body">${opts.contentHTML||''}</div>\n    <div class="modal-footer">\n      <button class="btn ghost" data-cancel>${opts.cancelText||'Cancel'}</button>\n      <button class="btn" data-submit>${opts.submitText||'Save'}</button>\n    </div>\n  </div>`;
+    document.body.appendChild(backdrop);
+    const modal = backdrop.querySelector('.modal');
+    const firstFocus = backdrop.querySelector('[data-close]');
+    firstFocus.focus();
+
+    function close(){
+      document.removeEventListener('keydown', trap);
+      backdrop.remove();
+    }
+    backdrop.addEventListener('click', e=>{ if(e.target===backdrop) close(); });
+    backdrop.querySelector('[data-close]').addEventListener('click', close);
+    backdrop.querySelector('[data-cancel]').addEventListener('click', ()=>{ close(); opts.onCancel && opts.onCancel(); });
+    backdrop.querySelector('[data-submit]').addEventListener('click', ()=>{ const res = opts.onSubmit && opts.onSubmit(); if(res!==false) close(); });
+    function trap(e){
+      if(e.key==='Escape') close();
+      if(e.key==='Tab'){
+        const focusable = backdrop.querySelectorAll('button, [href], input, textarea, select');
+        const first = focusable[0];
+        const last = focusable[focusable.length-1];
+        if(e.shiftKey && document.activeElement===first){ e.preventDefault(); last.focus(); }
+        else if(!e.shiftKey && document.activeElement===last){ e.preventDefault(); first.focus(); }
+      }
+    }
+    document.addEventListener('keydown', trap);
+    return { close };
+  };
+
+  // Skeleton
+  UI.skeleton = function(count=3, lines=3){
+    let html='';
+    for(let i=0;i<count;i++){
+      html += '<div class="card">';
+      for(let j=0;j<lines;j++) html += '<div class="skeleton"></div>';
+      html += '</div>';
+    }
+    return html;
+  };
+
+  // Theme management
+  function apply(theme){
+    const html=document.documentElement;
+    if(theme==='system') html.removeAttribute('data-theme');
+    else html.setAttribute('data-theme', theme);
+  }
+  UI.setTheme = function(theme){
+    localStorage.setItem('theme', theme);
+    apply(theme);
+  };
+  UI.initThemeToggle = function(){
+    const saved = localStorage.getItem('theme') || 'system';
+    apply(saved);
+    const btn = document.createElement('button');
+    btn.className='theme-toggle icon-btn';
+    btn.setAttribute('aria-label','Toggle theme');
+    btn.innerHTML='<i data-feather="moon"></i>';
+    const header=document.querySelector('.site-header');
+    header && header.appendChild(btn);
+    btn.addEventListener('click', ()=>{
+      const current = localStorage.getItem('theme') || 'system';
+      const next = current==='light' ? 'dark' : current==='dark' ? 'system' : 'light';
+      UI.setTheme(next);
+      btn.innerHTML = next==='dark' ? '<i data-feather="sun"></i>' : '<i data-feather="moon"></i>';
+      if(window.feather) feather.replace();
+    });
+  };
+
+  // Header utilities
+  function initHeader(){
+    const header=document.querySelector('.site-header');
+    if(!header) return;
+    const nav = header.querySelector('.navigation');
+    const toggle=document.createElement('button');
+    toggle.className='menu-toggle';
+    toggle.setAttribute('aria-label','Menu');
+    toggle.innerHTML='<i data-feather="menu"></i>';
+    header.insertBefore(toggle, nav);
+    toggle.addEventListener('click', ()=>{ nav.classList.toggle('open'); });
+    window.addEventListener('scroll', ()=>{
+      if(window.scrollY>10) header.classList.add('is-stuck');
+      else header.classList.remove('is-stuck');
+    });
+  }
+
+  // Ripple effect on buttons
+  document.addEventListener('click', e=>{
+    const btn = e.target.closest('.btn');
+    if(!btn || window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+    const circle=document.createElement('span');
+    const d=Math.max(btn.clientWidth, btn.clientHeight);
+    circle.style.width=circle.style.height=d+'px';
+    circle.style.left=e.clientX-btn.getBoundingClientRect().left-d/2+'px';
+    circle.style.top=e.clientY-btn.getBoundingClientRect().top-d/2+'px';
+    circle.className='ripple';
+    const rip=btn.getElementsByClassName('ripple')[0];
+    if(rip) rip.remove();
+    btn.appendChild(circle);
+    setTimeout(()=>circle.remove(),600);
+  });
+
+  document.addEventListener('DOMContentLoaded', ()=>{
+    UI.initThemeToggle();
+    initHeader();
+    if(window.feather) feather.replace();
+  });
+
+  window.UI = UI;
+})();

--- a/assets/site.webmanifest
+++ b/assets/site.webmanifest
@@ -1,0 +1,11 @@
+{
+  "name": "Freelancer Hub",
+  "short_name": "FH",
+  "icons": [
+    {"src": "favicon.svg", "sizes": "any", "type": "image/svg+xml"}
+  ],
+  "start_url": "./index.html",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#2563eb"
+}

--- a/client-dashboard.html
+++ b/client-dashboard.html
@@ -5,6 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Client Dashboard - Freelancer Hub</title>
   <link rel="stylesheet" href="style.css" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link rel="icon" href="assets/favicon.svg" type="image/svg+xml">
+<link rel="manifest" href="assets/site.webmanifest">
+<link rel="stylesheet" href="assets/css/theme.css">
+<script src="https://unpkg.com/feather-icons"></script>
+<script>document.addEventListener('DOMContentLoaded', () => { if (window.feather) feather.replace(); });</script>
 </head>
 <body>
   <header class="site-header">
@@ -52,6 +59,7 @@
     <p class="disclaimer">This website is for a class assignment and not for commercial purposes.</p>
   </footer>
 <script src="assets/js/auth-demo.js"></script>
+<script src="assets/js/ui.js"></script>
 <script src="assets/js/app-demo.js"></script>
 <script>
   document.addEventListener('DOMContentLoaded', () => {

--- a/contact.html
+++ b/contact.html
@@ -5,6 +5,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Contact Us - Freelancer Hub</title>
     <link rel="stylesheet" href="style.css" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link rel="icon" href="assets/favicon.svg" type="image/svg+xml">
+<link rel="manifest" href="assets/site.webmanifest">
+<link rel="stylesheet" href="assets/css/theme.css">
+<script src="https://unpkg.com/feather-icons"></script>
+<script>document.addEventListener('DOMContentLoaded', () => { if (window.feather) feather.replace(); });</script>
 </head>
 <body>
     <header class="site-header">
@@ -74,6 +81,7 @@
         });
     </script>
 <script src="assets/js/auth-demo.js"></script>
+<script src="assets/js/ui.js"></script>
 <script src="assets/js/app-demo.js"></script>
 </body>
 </html>

--- a/freelancer-dashboard.html
+++ b/freelancer-dashboard.html
@@ -5,6 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Freelancer Dashboard - Freelancer Hub</title>
   <link rel="stylesheet" href="style.css" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link rel="icon" href="assets/favicon.svg" type="image/svg+xml">
+<link rel="manifest" href="assets/site.webmanifest">
+<link rel="stylesheet" href="assets/css/theme.css">
+<script src="https://unpkg.com/feather-icons"></script>
+<script>document.addEventListener('DOMContentLoaded', () => { if (window.feather) feather.replace(); });</script>
 </head>
 <body>
   <header class="site-header">
@@ -52,6 +59,7 @@
     <p class="disclaimer">This website is for a class assignment and not for commercial purposes.</p>
   </footer>
 <script src="assets/js/auth-demo.js"></script>
+<script src="assets/js/ui.js"></script>
 <script src="assets/js/app-demo.js"></script>
 <script>
   document.addEventListener('DOMContentLoaded', () => {

--- a/index.html
+++ b/index.html
@@ -6,6 +6,13 @@
     <title>Freelancer Hub</title>
     <!-- Link to external stylesheet -->
     <link rel="stylesheet" href="style.css" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link rel="icon" href="assets/favicon.svg" type="image/svg+xml">
+<link rel="manifest" href="assets/site.webmanifest">
+<link rel="stylesheet" href="assets/css/theme.css">
+<script src="https://unpkg.com/feather-icons"></script>
+<script>document.addEventListener('DOMContentLoaded', () => { if (window.feather) feather.replace(); });</script>
 </head>
 <body>
     <!-- Header with navigation and call-to-action button -->
@@ -102,6 +109,7 @@
     </footer>
     
 <script src="assets/js/auth-demo.js"></script>
+<script src="assets/js/ui.js"></script>
 <script src="assets/js/app-demo.js"></script>
 </body>
 </html>

--- a/job-details.html
+++ b/job-details.html
@@ -5,6 +5,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Job Details - Freelancer Hub</title>
     <link rel="stylesheet" href="style.css" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link rel="icon" href="assets/favicon.svg" type="image/svg+xml">
+<link rel="manifest" href="assets/site.webmanifest">
+<link rel="stylesheet" href="assets/css/theme.css">
+<script src="https://unpkg.com/feather-icons"></script>
+<script>document.addEventListener('DOMContentLoaded', () => { if (window.feather) feather.replace(); });</script>
 </head>
 <body>
     <header class="site-header">
@@ -53,6 +60,7 @@
         <p class="disclaimer">This website is for a class assignment and not for commercial purposes.</p>
     </footer>
 <script src="assets/js/auth-demo.js"></script>
+<script src="assets/js/ui.js"></script>
 <script src="assets/js/app-demo.js"></script>
 </body>
 </html>

--- a/job-listings.html
+++ b/job-listings.html
@@ -5,6 +5,13 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Job Listings - Freelancer Hub</title>
     <link rel="stylesheet" href="style.css" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link rel="icon" href="assets/favicon.svg" type="image/svg+xml">
+<link rel="manifest" href="assets/site.webmanifest">
+<link rel="stylesheet" href="assets/css/theme.css">
+<script src="https://unpkg.com/feather-icons"></script>
+<script>document.addEventListener('DOMContentLoaded', () => { if (window.feather) feather.replace(); });</script>
 </head>
 <body>
     <header class="site-header">
@@ -37,6 +44,13 @@
 <main>
   <section class="section" style="max-width:1000px;margin:2rem auto;padding:0 1rem;">
     <h1>Job Listings</h1>
+    <form id="job-filters" class="filters">
+      <input id="f-q" placeholder="Search roles or skills">
+      <input id="f-loc" placeholder="Location">
+      <select id="f-type"><option value="">Any type</option><option>Full-time</option><option>Part-time</option><option>Contract</option><option>Internship</option></select>
+      <input id="f-salary" type="number" min="0" step="1000" placeholder="Min salary">
+      <select id="f-sort"><option value="new">Newest</option><option value="sal-asc">Salary ↑</option><option value="sal-desc">Salary ↓</option></select>
+    </form>
     <div id="job-list"></div>
   </section>
 </main>
@@ -52,10 +66,49 @@
         <p class="disclaimer">This website is for a class assignment and not for commercial purposes.</p>
     </footer>
 <script src="assets/js/auth-demo.js"></script>
+<script src="assets/js/ui.js"></script>
 <script src="assets/js/app-demo.js"></script>
 <script>
   document.addEventListener('DOMContentLoaded', () => {
-    window.appDemo.renderJobs('#job-list');
+    const list = document.getElementById('job-list');
+    const form = document.getElementById('job-filters');
+    const KEY = 'FH_FILTERS';
+    const saved = JSON.parse(localStorage.getItem(KEY) || '{}');
+    if(saved.q) document.getElementById('f-q').value = saved.q;
+    if(saved.loc) document.getElementById('f-loc').value = saved.loc;
+    if(saved.type) document.getElementById('f-type').value = saved.type;
+    if(saved.min) document.getElementById('f-salary').value = saved.min;
+    if(saved.sort) document.getElementById('f-sort').value = saved.sort;
+    function getFilters(){
+      return {
+        q: document.getElementById('f-q').value.toLowerCase(),
+        loc: document.getElementById('f-loc').value.toLowerCase(),
+        type: document.getElementById('f-type').value,
+        min: Number(document.getElementById('f-salary').value) || 0,
+        sort: document.getElementById('f-sort').value
+      };
+    }
+    function render(){
+      const f = getFilters();
+      localStorage.setItem(KEY, JSON.stringify(f));
+      list.innerHTML = UI.skeleton(3,3);
+      setTimeout(() => {
+        let jobs = window.appDemo.listJobs();
+        jobs = jobs.filter(j =>
+          (!f.q || j.title.toLowerCase().includes(f.q) || j.description.toLowerCase().includes(f.q)) &&
+          (!f.loc || j.location.toLowerCase().includes(f.loc)) &&
+          (!f.type || j.employmentType === f.type) &&
+          (!f.min || j.salary >= f.min)
+        );
+        if(f.sort === 'sal-asc') jobs.sort((a,b)=>a.salary-b.salary);
+        else if(f.sort === 'sal-desc') jobs.sort((a,b)=>b.salary-a.salary);
+        else jobs.sort((a,b)=>new Date(b.createdAt)-new Date(a.createdAt));
+        window.appDemo.renderJobs('#job-list', jobs);
+      }, 300);
+    }
+    form.addEventListener('input', render);
+    render();
+    window.appDemo.onJobsChanged(render);
   });
 </script>
 </body>

--- a/login.html
+++ b/login.html
@@ -5,6 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Login - Freelancer Hub</title>
   <link rel="stylesheet" href="style.css" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link rel="icon" href="assets/favicon.svg" type="image/svg+xml">
+<link rel="manifest" href="assets/site.webmanifest">
+<link rel="stylesheet" href="assets/css/theme.css">
+<script src="https://unpkg.com/feather-icons"></script>
+<script>document.addEventListener('DOMContentLoaded', () => { if (window.feather) feather.replace(); });</script>
 </head>
 <body>
   <header class="site-header">
@@ -68,6 +75,7 @@
     <p class="disclaimer">This website is for a class assignment and not for commercial purposes.</p>
   </footer>
 <script src="assets/js/auth-demo.js"></script>
+<script src="assets/js/ui.js"></script>
 <script src="assets/js/app-demo.js"></script>
 </body>
 </html>

--- a/logout.html
+++ b/logout.html
@@ -5,6 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Logging out...</title>
   <link rel="stylesheet" href="style.css" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link rel="icon" href="assets/favicon.svg" type="image/svg+xml">
+<link rel="manifest" href="assets/site.webmanifest">
+<link rel="stylesheet" href="assets/css/theme.css">
+<script src="https://unpkg.com/feather-icons"></script>
+<script>document.addEventListener('DOMContentLoaded', () => { if (window.feather) feather.replace(); });</script>
 </head>
 <body>
   <header class="site-header">
@@ -47,6 +54,7 @@
     <p class="disclaimer">This website is for a class assignment and not for commercial purposes.</p>
   </footer>
 <script src="assets/js/auth-demo.js"></script>
+<script src="assets/js/ui.js"></script>
 <script src="assets/js/app-demo.js"></script>
 </body>
 </html>

--- a/my-applications.html
+++ b/my-applications.html
@@ -5,6 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>My Applications - Freelancer Hub</title>
   <link rel="stylesheet" href="style.css" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link rel="icon" href="assets/favicon.svg" type="image/svg+xml">
+<link rel="manifest" href="assets/site.webmanifest">
+<link rel="stylesheet" href="assets/css/theme.css">
+<script src="https://unpkg.com/feather-icons"></script>
+<script>document.addEventListener('DOMContentLoaded', () => { if (window.feather) feather.replace(); });</script>
 </head>
 <body>
   <header class="site-header">
@@ -49,6 +56,7 @@
     <p class="disclaimer">This website is for a class assignment and not for commercial purposes.</p>
   </footer>
 <script src="assets/js/auth-demo.js"></script>
+<script src="assets/js/ui.js"></script>
 <script src="assets/js/app-demo.js"></script>
 <script>
   document.addEventListener('DOMContentLoaded', () => {

--- a/my-jobs.html
+++ b/my-jobs.html
@@ -5,6 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>My Jobs - Freelancer Hub</title>
   <link rel="stylesheet" href="style.css" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link rel="icon" href="assets/favicon.svg" type="image/svg+xml">
+<link rel="manifest" href="assets/site.webmanifest">
+<link rel="stylesheet" href="assets/css/theme.css">
+<script src="https://unpkg.com/feather-icons"></script>
+<script>document.addEventListener('DOMContentLoaded', () => { if (window.feather) feather.replace(); });</script>
 </head>
 <body>
   <header class="site-header">
@@ -49,6 +56,7 @@
     <p class="disclaimer">This website is for a class assignment and not for commercial purposes.</p>
   </footer>
 <script src="assets/js/auth-demo.js"></script>
+<script src="assets/js/ui.js"></script>
 <script src="assets/js/app-demo.js"></script>
 <script>
   document.addEventListener('DOMContentLoaded', () => {

--- a/post-job.html
+++ b/post-job.html
@@ -5,6 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Post a Job - Freelancer Hub</title>
   <link rel="stylesheet" href="style.css" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link rel="icon" href="assets/favicon.svg" type="image/svg+xml">
+<link rel="manifest" href="assets/site.webmanifest">
+<link rel="stylesheet" href="assets/css/theme.css">
+<script src="https://unpkg.com/feather-icons"></script>
+<script>document.addEventListener('DOMContentLoaded', () => { if (window.feather) feather.replace(); });</script>
 </head>
 <body>
   <header class="site-header">
@@ -69,6 +76,7 @@
     <p class="disclaimer">This website is for a class assignment and not for commercial purposes.</p>
   </footer>
 <script src="assets/js/auth-demo.js"></script>
+<script src="assets/js/ui.js"></script>
 <script src="assets/js/app-demo.js"></script>
 <script>
   document.addEventListener('DOMContentLoaded', () => {

--- a/profile.html
+++ b/profile.html
@@ -5,6 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Profile - Freelancer Hub</title>
   <link rel="stylesheet" href="style.css" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link rel="icon" href="assets/favicon.svg" type="image/svg+xml">
+<link rel="manifest" href="assets/site.webmanifest">
+<link rel="stylesheet" href="assets/css/theme.css">
+<script src="https://unpkg.com/feather-icons"></script>
+<script>document.addEventListener('DOMContentLoaded', () => { if (window.feather) feather.replace(); });</script>
 </head>
 <body>
   <header class="site-header">
@@ -52,6 +59,7 @@
     <p class="disclaimer">This website is for a class assignment and not for commercial purposes.</p>
   </footer>
 <script src="assets/js/auth-demo.js"></script>
+<script src="assets/js/ui.js"></script>
 <script src="assets/js/app-demo.js"></script>
 <script>
   document.addEventListener('DOMContentLoaded', () => {

--- a/register.html
+++ b/register.html
@@ -5,6 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Register - Freelancer Hub</title>
   <link rel="stylesheet" href="style.css" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link rel="icon" href="assets/favicon.svg" type="image/svg+xml">
+<link rel="manifest" href="assets/site.webmanifest">
+<link rel="stylesheet" href="assets/css/theme.css">
+<script src="https://unpkg.com/feather-icons"></script>
+<script>document.addEventListener('DOMContentLoaded', () => { if (window.feather) feather.replace(); });</script>
 </head>
 <body>
   <header class="site-header">
@@ -71,6 +78,7 @@
     <p class="disclaimer">This website is for a class assignment and not for commercial purposes.</p>
   </footer>
 <script src="assets/js/auth-demo.js"></script>
+<script src="assets/js/ui.js"></script>
 <script src="assets/js/app-demo.js"></script>
 </body>
 </html>

--- a/saved-jobs.html
+++ b/saved-jobs.html
@@ -5,6 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Saved Jobs - Freelancer Hub</title>
   <link rel="stylesheet" href="style.css" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+<link rel="icon" href="assets/favicon.svg" type="image/svg+xml">
+<link rel="manifest" href="assets/site.webmanifest">
+<link rel="stylesheet" href="assets/css/theme.css">
+<script src="https://unpkg.com/feather-icons"></script>
+<script>document.addEventListener('DOMContentLoaded', () => { if (window.feather) feather.replace(); });</script>
 </head>
 <body>
   <header class="site-header">
@@ -49,6 +56,7 @@
     <p class="disclaimer">This website is for a class assignment and not for commercial purposes.</p>
   </footer>
 <script src="assets/js/auth-demo.js"></script>
+<script src="assets/js/ui.js"></script>
 <script src="assets/js/app-demo.js"></script>
 <script>
   document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- Introduce global design tokens with light/dark theme support and component refinements
- Add reusable UI helpers (toasts, modals, skeleton loader, theme toggle, sticky header & mobile menu)
- Enhance job listings with filter bar, persisted filters and skeleton loading
- Use SVG favicon to avoid binary assets

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a1586cd84c832a95da2ad11a9a3d53